### PR TITLE
Add as_decimal_seconds to Coordinate

### DIFF
--- a/navigation/units.py
+++ b/navigation/units.py
@@ -186,6 +186,10 @@ class Coordinate(object):
         else:
             return decimal
 
+    @property
+    def as_decimal_seconds(self):
+        return (self._degrees, self._minutes, (self._seconds/60), self._compass)
+
 
 class Waypoint(object):
     def __init__(self, latitude, longitude):

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -157,6 +157,14 @@ class TestCoordinate(unittest.TestCase):
         self.assertAlmostEqual(coordinate.as_decimal,
                                Decimal(-10.755277777777778))
 
+    def test_returns_as_decimal_seconds(self):
+        coordinate = Coordinate(2, 46, 15, "W")
+        self.assertEqual(coordinate.as_decimal_seconds, (2, 46, .25, "W"))
+
+    def test_returns_as_decimal_seconds_zero_seconds(self):
+        coordinate = Coordinate(2, 46, 0, "W")
+        self.assertEqual(coordinate.as_decimal_seconds, (2, 46, 0, "W"))
+
 
 class TestWaypoint(unittest.TestCase):
     def test_waypoint_initailises_with_coordinates(self):


### PR DESCRIPTION
Returns seconds as decimal seconds which is useful for navigation.